### PR TITLE
fix category service interface typo

### DIFF
--- a/order_service/src/main/java/com/example/microservice_demo/service/ICategoryService.java
+++ b/order_service/src/main/java/com/example/microservice_demo/service/ICategoryService.java
@@ -4,7 +4,7 @@ import com.example.microservice_demo.model.Category;
 
 import java.util.List;
 
-public interface ICategoryServire {
+public interface ICategoryService {
 
 
     public List<Category> getAll();

--- a/order_service/src/main/java/com/example/microservice_demo/service/serviceImpl/CategoryService.java
+++ b/order_service/src/main/java/com/example/microservice_demo/service/serviceImpl/CategoryService.java
@@ -2,14 +2,14 @@ package com.example.microservice_demo.service.serviceImpl;
 
 import com.example.microservice_demo.model.Category;
 import com.example.microservice_demo.repository.CategoryRepo;
-import com.example.microservice_demo.service.ICategoryServire;
+import com.example.microservice_demo.service.ICategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class CategoryService implements ICategoryServire {
+public class CategoryService implements ICategoryService {
 
     @Autowired
     private CategoryRepo categoryRepo;


### PR DESCRIPTION
## Summary
- rename `ICategoryServire` to `ICategoryService`
- update `CategoryService` to implement the corrected interface

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bf207491d88323bcff4f311978ad0c