### PR TITLE
feat: implement saga workflow with Kafka

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,57 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - microservice_system
+  kafka:
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    networks:
+      - microservice_system
+  order_service:
+    build: ./order_service
+    depends_on:
+      - kafka
+    ports:
+      - "8080:8080"
+    networks:
+      - microservice_system
+  payment_service:
+    build: ./payment_service
+    depends_on:
+      - kafka
+    ports:
+      - "8082:8082"
+    networks:
+      - microservice_system
+  inventory_service:
+    build: ./inventory_service
+    depends_on:
+      - kafka
+    ports:
+      - "8083:8083"
+    networks:
+      - microservice_system
+  job_service:
+    build: ./job_service
+    depends_on:
+      - kafka
+    ports:
+      - "8081:8081"
+    networks:
+      - microservice_system
+networks:
+  microservice_system:
+    driver: bridge

--- a/inventory_service/Dockerfile
+++ b/inventory_service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:latest
+WORKDIR /app
+COPY target/inventory_service.jar /app/inventory_service.jar
+EXPOSE 8083
+ENTRYPOINT ["java","-jar","inventory_service.jar"]

--- a/inventory_service/docker-compose.yaml
+++ b/inventory_service/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  inventory_service:
+    build: .
+    image: inventory_service:latest
+    container_name: inventory_service
+    ports:
+      - "8083:8083"
+    networks:
+      - microservice_system
+networks:
+  microservice_system:
+    external: true

--- a/inventory_service/pom.xml
+++ b/inventory_service/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.1</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>inventory_service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>inventory_service</name>
+    <description>inventory_service</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>inventory_service</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/inventory_service/src/main/java/com/example/inventory_service/InventoryServiceApplication.java
+++ b/inventory_service/src/main/java/com/example/inventory_service/InventoryServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.inventory_service;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class InventoryServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(InventoryServiceApplication.class, args);
+    }
+}

--- a/inventory_service/src/main/java/com/example/inventory_service/kafka/InventoryProducer.java
+++ b/inventory_service/src/main/java/com/example/inventory_service/kafka/InventoryProducer.java
@@ -1,0 +1,21 @@
+package com.example.inventory_service.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InventoryProducer {
+    private final KafkaTemplate<String, OrderEvent> kafkaTemplate;
+
+    public InventoryProducer(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendInventoryReserved(OrderEvent event) {
+        kafkaTemplate.send("inventory-reserved", event);
+    }
+
+    public void sendInventoryRollback(OrderEvent event) {
+        kafkaTemplate.send("inventory-rollback", event);
+    }
+}

--- a/inventory_service/src/main/java/com/example/inventory_service/kafka/OrderEvent.java
+++ b/inventory_service/src/main/java/com/example/inventory_service/kafka/OrderEvent.java
@@ -1,0 +1,19 @@
+package com.example.inventory_service.kafka;
+
+public class OrderEvent {
+    private Long orderId;
+
+    public OrderEvent() {}
+
+    public OrderEvent(Long orderId) {
+        this.orderId = orderId;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(Long orderId) {
+        this.orderId = orderId;
+    }
+}

--- a/inventory_service/src/main/java/com/example/inventory_service/kafka/PaymentConsumer.java
+++ b/inventory_service/src/main/java/com/example/inventory_service/kafka/PaymentConsumer.java
@@ -1,0 +1,22 @@
+package com.example.inventory_service.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentConsumer {
+    private final InventoryProducer inventoryProducer;
+
+    public PaymentConsumer(InventoryProducer inventoryProducer) {
+        this.inventoryProducer = inventoryProducer;
+    }
+
+    @KafkaListener(topics = "payment-completed", groupId = "inventory-service")
+    public void consume(OrderEvent event) {
+        if (event.getOrderId() % 3 == 0) {
+            inventoryProducer.sendInventoryRollback(event);
+        } else {
+            inventoryProducer.sendInventoryReserved(event);
+        }
+    }
+}

--- a/inventory_service/src/main/resources/application.yml
+++ b/inventory_service/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+server:
+  port: 8083
+spring:
+  application:
+    name: inventory-service
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: inventory-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: '*'
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer

--- a/job_service/Dockerfile
+++ b/job_service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:latest
+WORKDIR /app
+COPY target/job_service.jar /app/job_service.jar
+EXPOSE 8081
+ENTRYPOINT ["java","-jar","job_service.jar"]

--- a/job_service/pom.xml
+++ b/job_service/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>

--- a/job_service/src/main/java/com/example/job_service/kafka/OrderEvent.java
+++ b/job_service/src/main/java/com/example/job_service/kafka/OrderEvent.java
@@ -1,0 +1,19 @@
+package com.example.job_service.kafka;
+
+public class OrderEvent {
+    private Long orderId;
+
+    public OrderEvent() {}
+
+    public OrderEvent(Long orderId) {
+        this.orderId = orderId;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(Long orderId) {
+        this.orderId = orderId;
+    }
+}

--- a/job_service/src/main/java/com/example/job_service/kafka/ShippingConsumer.java
+++ b/job_service/src/main/java/com/example/job_service/kafka/ShippingConsumer.java
@@ -1,0 +1,22 @@
+package com.example.job_service.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShippingConsumer {
+    private final ShippingProducer shippingProducer;
+
+    public ShippingConsumer(ShippingProducer shippingProducer) {
+        this.shippingProducer = shippingProducer;
+    }
+
+    @KafkaListener(topics = "inventory-reserved", groupId = "shipping-service")
+    public void consume(OrderEvent event) {
+        if (event.getOrderId() % 5 == 0) {
+            shippingProducer.sendShippingFailed(event);
+        } else {
+            shippingProducer.sendOrderCompleted(event);
+        }
+    }
+}

--- a/job_service/src/main/java/com/example/job_service/kafka/ShippingProducer.java
+++ b/job_service/src/main/java/com/example/job_service/kafka/ShippingProducer.java
@@ -1,0 +1,21 @@
+package com.example.job_service.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ShippingProducer {
+    private final KafkaTemplate<String, OrderEvent> kafkaTemplate;
+
+    public ShippingProducer(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendOrderCompleted(OrderEvent event) {
+        kafkaTemplate.send("order-completed", event);
+    }
+
+    public void sendShippingFailed(OrderEvent event) {
+        kafkaTemplate.send("shipping-failed", event);
+    }
+}

--- a/job_service/src/main/resources/application.yml
+++ b/job_service/src/main/resources/application.yml
@@ -24,3 +24,18 @@ eureka:
       defaultZone: http://192.168.0.3:9761/eureka
     register-with-eureka: false
     fetch-registry: false
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: shipping-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: '*'
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer

--- a/order_service/pom.xml
+++ b/order_service/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
             <version>4.1.0</version>

--- a/order_service/src/main/java/com/example/microservice_demo/kafka/OrderEvent.java
+++ b/order_service/src/main/java/com/example/microservice_demo/kafka/OrderEvent.java
@@ -1,0 +1,20 @@
+package com.example.microservice_demo.kafka;
+
+public class OrderEvent {
+    private Long orderId;
+
+    public OrderEvent() {
+    }
+
+    public OrderEvent(Long orderId) {
+        this.orderId = orderId;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(Long orderId) {
+        this.orderId = orderId;
+    }
+}

--- a/order_service/src/main/java/com/example/microservice_demo/kafka/OrderProducer.java
+++ b/order_service/src/main/java/com/example/microservice_demo/kafka/OrderProducer.java
@@ -1,0 +1,17 @@
+package com.example.microservice_demo.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderProducer {
+    private final KafkaTemplate<String, OrderEvent> kafkaTemplate;
+
+    public OrderProducer(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendOrderCreated(Long orderId) {
+        kafkaTemplate.send("order-created", new OrderEvent(orderId));
+    }
+}

--- a/order_service/src/main/java/com/example/microservice_demo/kafka/OrderSagaListener.java
+++ b/order_service/src/main/java/com/example/microservice_demo/kafka/OrderSagaListener.java
@@ -1,0 +1,31 @@
+package com.example.microservice_demo.kafka;
+
+import com.example.microservice_demo.model.Order;
+import com.example.microservice_demo.repository.OrderRepo;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderSagaListener {
+    private final OrderRepo orderRepo;
+
+    public OrderSagaListener(OrderRepo orderRepo) {
+        this.orderRepo = orderRepo;
+    }
+
+    @KafkaListener(topics = {"payment-failed", "inventory-rollback", "shipping-failed"}, groupId = "order-service")
+    public void handleFailed(OrderEvent event) {
+        orderRepo.findById(event.getOrderId()).ifPresent(order -> {
+            order.setOrderStatus("cancelled");
+            orderRepo.save(order);
+        });
+    }
+
+    @KafkaListener(topics = "order-completed", groupId = "order-service")
+    public void handleCompleted(OrderEvent event) {
+        orderRepo.findById(event.getOrderId()).ifPresent(order -> {
+            order.setOrderStatus("completed");
+            orderRepo.save(order);
+        });
+    }
+}

--- a/order_service/src/main/java/com/example/microservice_demo/service/serviceImpl/OrderService.java
+++ b/order_service/src/main/java/com/example/microservice_demo/service/serviceImpl/OrderService.java
@@ -30,6 +30,12 @@ public class OrderService implements IOrderService {
 
     @Autowired
     private GetInforUser getInforUser;
+
+    private final com.example.microservice_demo.kafka.OrderProducer orderProducer;
+
+    public OrderService(com.example.microservice_demo.kafka.OrderProducer orderProducer) {
+        this.orderProducer = orderProducer;
+    }
     @Override
     public List<Order> getAll() {
         logger.info("service");
@@ -57,6 +63,7 @@ public class OrderService implements IOrderService {
         }
         order.setProducts(productRepo.findAllById(ids));
         orderRepo.save(order);
+        orderProducer.sendOrderCreated(order.getId());
         return order;
     }
 

--- a/order_service/src/main/resources/application.yml
+++ b/order_service/src/main/resources/application.yml
@@ -19,6 +19,21 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
   application:
     name: order-service
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: order-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: '*'
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 #
 #spring.jpa.hibernate.ddl-auto=update
 #spring.jpa.show-sql=true

--- a/payment_service/Dockerfile
+++ b/payment_service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:latest
+WORKDIR /app
+COPY target/payment_service.jar /app/payment_service.jar
+EXPOSE 8082
+ENTRYPOINT ["java","-jar","payment_service.jar"]

--- a/payment_service/docker-compose.yaml
+++ b/payment_service/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  payment_service:
+    build: .
+    image: payment_service:latest
+    container_name: payment_service
+    ports:
+      - "8082:8082"
+    networks:
+      - microservice_system
+networks:
+  microservice_system:
+    external: true

--- a/payment_service/pom.xml
+++ b/payment_service/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.1</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>payment_service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>payment_service</name>
+    <description>payment_service</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>payment_service</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/payment_service/src/main/java/com/example/payment_service/PaymentServiceApplication.java
+++ b/payment_service/src/main/java/com/example/payment_service/PaymentServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.payment_service;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PaymentServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PaymentServiceApplication.class, args);
+    }
+}

--- a/payment_service/src/main/java/com/example/payment_service/kafka/OrderEvent.java
+++ b/payment_service/src/main/java/com/example/payment_service/kafka/OrderEvent.java
@@ -1,0 +1,20 @@
+package com.example.payment_service.kafka;
+
+public class OrderEvent {
+    private Long orderId;
+
+    public OrderEvent() {
+    }
+
+    public OrderEvent(Long orderId) {
+        this.orderId = orderId;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(Long orderId) {
+        this.orderId = orderId;
+    }
+}

--- a/payment_service/src/main/java/com/example/payment_service/kafka/PaymentConsumer.java
+++ b/payment_service/src/main/java/com/example/payment_service/kafka/PaymentConsumer.java
@@ -1,0 +1,22 @@
+package com.example.payment_service.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentConsumer {
+    private final PaymentProducer paymentProducer;
+
+    public PaymentConsumer(PaymentProducer paymentProducer) {
+        this.paymentProducer = paymentProducer;
+    }
+
+    @KafkaListener(topics = "order-created", groupId = "payment-service")
+    public void consume(OrderEvent event) {
+        if (event.getOrderId() % 2 == 0) {
+            paymentProducer.sendPaymentCompleted(event);
+        } else {
+            paymentProducer.sendPaymentFailed(event);
+        }
+    }
+}

--- a/payment_service/src/main/java/com/example/payment_service/kafka/PaymentProducer.java
+++ b/payment_service/src/main/java/com/example/payment_service/kafka/PaymentProducer.java
@@ -1,0 +1,21 @@
+package com.example.payment_service.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentProducer {
+    private final KafkaTemplate<String, OrderEvent> kafkaTemplate;
+
+    public PaymentProducer(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendPaymentCompleted(OrderEvent event) {
+        kafkaTemplate.send("payment-completed", event);
+    }
+
+    public void sendPaymentFailed(OrderEvent event) {
+        kafkaTemplate.send("payment-failed", event);
+    }
+}

--- a/payment_service/src/main/resources/application.yml
+++ b/payment_service/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+server:
+  port: 8082
+spring:
+  application:
+    name: payment-service
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: payment-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: '*'
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
## Summary
- integrate Spring Kafka into order_service to publish `order-created` events and handle saga compensation events
- add new payment_service and inventory_service to process order workflow and emit subsequent Kafka events
- enable job_service to act as shipping service and finalize or compensate orders
- add docker-compose with Kafka broker and all services

## Testing
- `mvn -q -f order_service/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `mvn -q -f payment_service/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `mvn -q -f inventory_service/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `mvn -q -f job_service/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68bf22e53fc48323be0f8ec76dfd858c