### PR TITLE
Add refund request support and refund service

### DIFF
--- a/order_service/src/main/java/com/example/microservice_demo/controller/OrderController.java
+++ b/order_service/src/main/java/com/example/microservice_demo/controller/OrderController.java
@@ -4,6 +4,7 @@ package com.example.microservice_demo.controller;
 import com.example.microservice_demo.controller.request.CreateOrderRequest;
 import com.example.microservice_demo.repository.OrderRepo;
 import com.example.microservice_demo.service.IOrderService;
+import com.example.microservice_demo.kafka.OrderProducer;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,9 @@ public class OrderController {
 
     @Autowired
     private GetInforUser getInforUser;
+
+    @Autowired
+    private OrderProducer orderProducer;
 
 
     @GetMapping("")
@@ -46,5 +50,11 @@ public class OrderController {
     @PostMapping("")
     public ResponseEntity<?> create(@RequestBody CreateOrderRequest createOrderRequest){
         return new ResponseEntity<>(orderService.create(createOrderRequest), HttpStatus.OK);
+    }
+
+    @PostMapping("/{id}/refund")
+    public ResponseEntity<?> requestRefund(@PathVariable Long id) {
+        orderProducer.sendRefundRequested(id);
+        return new ResponseEntity<>("Refund requested", HttpStatus.OK);
     }
 }

--- a/order_service/src/main/java/com/example/microservice_demo/kafka/OrderProducer.java
+++ b/order_service/src/main/java/com/example/microservice_demo/kafka/OrderProducer.java
@@ -14,4 +14,8 @@ public class OrderProducer {
     public void sendOrderCreated(Long orderId) {
         kafkaTemplate.send("order-created", new OrderEvent(orderId));
     }
+
+    public void sendRefundRequested(Long orderId) {
+        kafkaTemplate.send("refund-requested", new OrderEvent(orderId));
+    }
 }

--- a/order_service/src/main/java/com/example/microservice_demo/kafka/OrderSagaListener.java
+++ b/order_service/src/main/java/com/example/microservice_demo/kafka/OrderSagaListener.java
@@ -28,4 +28,28 @@ public class OrderSagaListener {
             orderRepo.save(order);
         });
     }
+
+    @KafkaListener(topics = "payment-refunded", groupId = "order-service")
+    public void handlePaymentRefunded(OrderEvent event) {
+        orderRepo.findById(event.getOrderId()).ifPresent(order -> {
+            order.setOrderStatus("payment_refunded");
+            orderRepo.save(order);
+        });
+    }
+
+    @KafkaListener(topics = "inventory-restored", groupId = "order-service")
+    public void handleInventoryRestored(OrderEvent event) {
+        orderRepo.findById(event.getOrderId()).ifPresent(order -> {
+            order.setOrderStatus("inventory_restored");
+            orderRepo.save(order);
+        });
+    }
+
+    @KafkaListener(topics = "shipping-returned", groupId = "order-service")
+    public void handleShippingReturned(OrderEvent event) {
+        orderRepo.findById(event.getOrderId()).ifPresent(order -> {
+            order.setOrderStatus("shipping_returned");
+            orderRepo.save(order);
+        });
+    }
 }

--- a/refund_service/Dockerfile
+++ b/refund_service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:latest
+WORKDIR /app
+COPY target/refund_service.jar /app/refund_service.jar
+EXPOSE 8084
+ENTRYPOINT ["java","-jar","refund_service.jar"]

--- a/refund_service/docker-compose.yaml
+++ b/refund_service/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  refund_service:
+    build: .
+    image: refund_service:latest
+    container_name: refund_service
+    ports:
+      - "8084:8084"
+    networks:
+      - microservice_system
+networks:
+  microservice_system:
+    external: true

--- a/refund_service/pom.xml
+++ b/refund_service/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.1</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>refund_service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>refund_service</name>
+    <description>refund_service</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>refund_service</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/refund_service/src/main/java/com/example/refund_service/RefundServiceApplication.java
+++ b/refund_service/src/main/java/com/example/refund_service/RefundServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.refund_service;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class RefundServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(RefundServiceApplication.class, args);
+    }
+}

--- a/refund_service/src/main/java/com/example/refund_service/kafka/OrderEvent.java
+++ b/refund_service/src/main/java/com/example/refund_service/kafka/OrderEvent.java
@@ -1,0 +1,20 @@
+package com.example.refund_service.kafka;
+
+public class OrderEvent {
+    private Long orderId;
+
+    public OrderEvent() {
+    }
+
+    public OrderEvent(Long orderId) {
+        this.orderId = orderId;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(Long orderId) {
+        this.orderId = orderId;
+    }
+}

--- a/refund_service/src/main/java/com/example/refund_service/kafka/RefundConsumer.java
+++ b/refund_service/src/main/java/com/example/refund_service/kafka/RefundConsumer.java
@@ -1,0 +1,18 @@
+package com.example.refund_service.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefundConsumer {
+    private final RefundProducer refundProducer;
+
+    public RefundConsumer(RefundProducer refundProducer) {
+        this.refundProducer = refundProducer;
+    }
+
+    @KafkaListener(topics = "refund-requested", groupId = "refund-service")
+    public void consume(OrderEvent event) {
+        refundProducer.sendPaymentRefunded(event);
+    }
+}

--- a/refund_service/src/main/java/com/example/refund_service/kafka/RefundProducer.java
+++ b/refund_service/src/main/java/com/example/refund_service/kafka/RefundProducer.java
@@ -1,0 +1,17 @@
+package com.example.refund_service.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RefundProducer {
+    private final KafkaTemplate<String, OrderEvent> kafkaTemplate;
+
+    public RefundProducer(KafkaTemplate<String, OrderEvent> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendPaymentRefunded(OrderEvent event) {
+        kafkaTemplate.send("payment-refunded", event);
+    }
+}

--- a/refund_service/src/main/resources/application.yml
+++ b/refund_service/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+server:
+  port: 8084
+spring:
+  application:
+    name: refund-service
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: refund-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: '*'
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
## Summary
- add refund request endpoint in order service
- handle refund-related saga events
- introduce refund_service with Kafka consumer/producer

## Testing
- `mvn -q -f order_service/pom.xml test` *(fails: Network is unreachable for Maven Central)*
- `mvn -q -f refund_service/pom.xml test` *(fails: Network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa43eee6083238c7bf53071e09249