### PR TITLE
feat: expose prometheus metrics

### DIFF
--- a/Authen_service/pom.xml
+++ b/Authen_service/pom.xml
@@ -101,6 +101,14 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Authen_service/src/main/resources/application.yml
+++ b/Authen_service/src/main/resources/application.yml
@@ -35,3 +35,12 @@ eureka:
       defaultZone: http://192.168.2.182:8761/eureka
     register-with-eureka: true
     fetch-registry: true
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true

--- a/customer_service/pom.xml
+++ b/customer_service/pom.xml
@@ -61,12 +61,20 @@
 			<artifactId>spring-boot-starter-tomcat</artifactId>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+    </dependencies>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/customer_service/src/main/resources/application.yml
+++ b/customer_service/src/main/resources/application.yml
@@ -25,3 +25,12 @@ eureka:
       defaultZone: http://discovery:8761/eureka
     register-with-eureka: true
     fetch-registry: true
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true

--- a/discovery_service/pom.xml
+++ b/discovery_service/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>spring-cloud-netflix-eureka-server</artifactId>
             <version>4.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
 
     </dependencies>
     <dependencyManagement>

--- a/discovery_service/src/main/resources/application.properties
+++ b/discovery_service/src/main/resources/application.properties
@@ -2,3 +2,5 @@ spring.application.name=discovery-server
 server.port=8761
 eureka.client.register-with-eureka=false
 eureka.client.fetch-registry=false
+management.endpoints.web.exposure.include=prometheus
+management.metrics.export.prometheus.enabled=true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,27 @@ services:
       - "8081:8081"
     networks:
       - microservice_system
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - order_service
+      - payment_service
+      - inventory_service
+      - job_service
+    networks:
+      - microservice_system
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    networks:
+      - microservice_system
 networks:
   microservice_system:
     driver: bridge

--- a/gateway_service/pom.xml
+++ b/gateway_service/pom.xml
@@ -70,20 +70,28 @@
 		</dependency>
 
 		<!-- JJWT Jackson Processor -->
-		<dependency>
-			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-jackson</artifactId> <!-- or jjwt-orgjson if you prefer -->
-			<version>0.11.2</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
-		<dependency>
-			<groupId>com.auth0</groupId>
-			<artifactId>java-jwt</artifactId>
-			<version>4.4.0</version>
-		</dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId> <!-- or jjwt-orgjson if you prefer -->
+            <version>0.11.2</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>4.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
 
 
-	</dependencies>
+    </dependencies>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/gateway_service/src/main/resources/application.yml
+++ b/gateway_service/src/main/resources/application.yml
@@ -11,6 +11,15 @@ eureka:
       defaultZone: http://discovery:8761/eureka
     register-with-eureka: true
     fetch-registry: true
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true
 
 
 

--- a/inventory_service/pom.xml
+++ b/inventory_service/pom.xml
@@ -34,6 +34,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/inventory_service/src/main/resources/application.yml
+++ b/inventory_service/src/main/resources/application.yml
@@ -18,3 +18,12 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true

--- a/job_service/pom.xml
+++ b/job_service/pom.xml
@@ -99,6 +99,15 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
 
     </dependencies>
     <dependencyManagement>

--- a/job_service/src/main/resources/application.yml
+++ b/job_service/src/main/resources/application.yml
@@ -39,3 +39,12 @@ eureka:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true

--- a/order_service/pom.xml
+++ b/order_service/pom.xml
@@ -89,6 +89,15 @@
             <version>5.7.8</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
 
     </dependencies>
 

--- a/order_service/src/main/resources/application.yml
+++ b/order_service/src/main/resources/application.yml
@@ -34,20 +34,20 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-#
-#spring.jpa.hibernate.ddl-auto=update
-#spring.jpa.show-sql=true
-#spring.jpa.properties.hibernate.format_sql=true
-#
-#
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true
 eureka:
   client:
     serviceUrl:
       defaultZone: http://192.168.2.182:8761/eureka
     register-with-eureka: true
     fetch-registry: true
-#eureka.client.register-with-eureka=true
-#eureka.client.fetch-registry=true
-#spring.application.name=microservice-demo
 
 

--- a/payment_service/pom.xml
+++ b/payment_service/pom.xml
@@ -34,6 +34,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/payment_service/src/main/resources/application.yml
+++ b/payment_service/src/main/resources/application.yml
@@ -18,3 +18,12 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,20 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'order_service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['order_service:8080']
+  - job_name: 'payment_service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['payment_service:8082']
+  - job_name: 'inventory_service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['inventory_service:8083']
+  - job_name: 'job_service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['job_service:8081']

--- a/refund_service/pom.xml
+++ b/refund_service/pom.xml
@@ -34,6 +34,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/refund_service/src/main/resources/application.yml
+++ b/refund_service/src/main/resources/application.yml
@@ -18,3 +18,12 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true


### PR DESCRIPTION
## Summary
- add Prometheus micrometer registry and actuator to each service
- expose `/actuator/prometheus` endpoints in service configs
- integrate Prometheus and Grafana via docker-compose

## Testing
- `for dir in Authen_service customer_service discovery_service gateway_service inventory_service job_service order_service payment_service refund_service; do echo "Running tests for $dir"; mvn -q -f $dir/pom.xml test; done` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d1d66ccc832390699ef64c558ac7