### PR TITLE
Enable Prometheus metrics scraping for all services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-"# microservice_demo" 
+# Microservice Demo
+
+This project demonstrates a set of Spring Boot microservices.
+
+### Observability
+
+Every service exposes Prometheus metrics at `/actuator/prometheus` and
+includes the Micrometer Prometheus registry. The provided
+`docker-compose.yaml` starts Prometheus and Grafana along with the
+services. Prometheus is configured to scrape each service and Grafana can
+be used to build dashboards for monitoring.
+
+To launch the stack:
+
+```bash
+docker-compose up --build
+```
+
+Prometheus will be available at http://localhost:9090 and Grafana at
+http://localhost:3000.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,44 @@ services:
       - "8081:8081"
     networks:
       - microservice_system
+  gateway_service:
+    build: ./gateway_service
+    depends_on:
+      - kafka
+    ports:
+      - "8088:8088"
+    networks:
+      - microservice_system
+  authen_service:
+    build: ./Authen_service
+    depends_on:
+      - kafka
+    ports:
+      - "8888:8888"
+    networks:
+      - microservice_system
+  customer_service:
+    build: ./customer_service
+    depends_on:
+      - kafka
+    ports:
+      - "8085:8082"
+    networks:
+      - microservice_system
+  refund_service:
+    build: ./refund_service
+    depends_on:
+      - kafka
+    ports:
+      - "8084:8084"
+    networks:
+      - microservice_system
+  discovery_service:
+    build: ./discovery_service
+    ports:
+      - "8761:8761"
+    networks:
+      - microservice_system
   prometheus:
     image: prom/prometheus:latest
     volumes:
@@ -63,6 +101,11 @@ services:
       - payment_service
       - inventory_service
       - job_service
+      - gateway_service
+      - authen_service
+      - customer_service
+      - refund_service
+      - discovery_service
     networks:
       - microservice_system
   grafana:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -18,3 +18,23 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['job_service:8081']
+  - job_name: 'gateway_service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['gateway_service:8088']
+  - job_name: 'authen_service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['authen_service:8888']
+  - job_name: 'customer_service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['customer_service:8082']
+  - job_name: 'refund_service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['refund_service:8084']
+  - job_name: 'discovery_service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['discovery_service:8761']


### PR DESCRIPTION
## Summary
- add all microservices to Prometheus scrape configs
- extend docker-compose with Prometheus & Grafana stack
- document monitoring setup in README

## Testing
- `python -c "import yaml; yaml.safe_load(open('prometheus/prometheus.yml')); print('prometheus config OK')"`
- `python -c "import yaml; yaml.safe_load(open('docker-compose.yaml')); print('compose config OK')"`
- `mvn -q -f order_service/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b059bb0c8323bfcd3e960acd60bc