### PR TITLE
provisioning (Data Source cho Grafana, để khi container khởi động là có sẵn kết nối Prometheus.có thể thêm bằng UI hoặc gọi Grafana HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,6 @@ docker-compose up --build
 ```
 
 Prometheus will be available at http://localhost:9090 and Grafana at
-http://localhost:3000.
+http://localhost:3000. Grafana is automatically configured with a
+Prometheus datasource, so you can start building dashboards without
+any manual setup.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -112,6 +112,10 @@ services:
     image: grafana/grafana:latest
     ports:
       - "3000:3000"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    environment:
+      GF_PATHS_PROVISIONING: /etc/grafana/provisioning
     depends_on:
       - prometheus
     networks:

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true


### PR DESCRIPTION
## Summary
- provision Grafana with a Prometheus datasource
- mount provisioning directory in `docker-compose.yaml` and expose default path
- document auto-configured Grafana Prometheus datasource

## Testing
- `docker-compose config` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_e_68c1c179e75883239a4058c98e6ba0c0