### PR TITLE
Enable Redis cache for order service

### DIFF
--- a/order_service/pom.xml
+++ b/order_service/pom.xml
@@ -98,6 +98,15 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+
 
     </dependencies>
 

--- a/order_service/src/main/java/com/example/microservice_demo/MicroserviceDemoApplication.java
+++ b/order_service/src/main/java/com/example/microservice_demo/MicroserviceDemoApplication.java
@@ -4,11 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cache.annotation.EnableCaching;
 
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableFeignClients
+@EnableCaching
 public class MicroserviceDemoApplication {
 
     public static void main(String[] args) {

--- a/order_service/src/main/java/com/example/microservice_demo/config/RedisCacheConfig.java
+++ b/order_service/src/main/java/com/example/microservice_demo/config/RedisCacheConfig.java
@@ -1,0 +1,25 @@
+package com.example.microservice_demo.config;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/order_service/src/main/java/com/example/microservice_demo/service/serviceImpl/CategoryService.java
+++ b/order_service/src/main/java/com/example/microservice_demo/service/serviceImpl/CategoryService.java
@@ -5,6 +5,7 @@ import com.example.microservice_demo.repository.CategoryRepo;
 import com.example.microservice_demo.service.ICategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.cache.annotation.Cacheable;
 
 import java.util.List;
 
@@ -14,6 +15,7 @@ public class CategoryService implements ICategoryService {
     @Autowired
     private CategoryRepo categoryRepo;
     @Override
+    @Cacheable("categories")
     public List<Category> getAll() {
         return categoryRepo.findAll();
     }

--- a/order_service/src/main/java/com/example/microservice_demo/service/serviceImpl/OrderService.java
+++ b/order_service/src/main/java/com/example/microservice_demo/service/serviceImpl/OrderService.java
@@ -11,6 +11,8 @@ import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.CacheEvict;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -37,12 +39,14 @@ public class OrderService implements IOrderService {
         this.orderProducer = orderProducer;
     }
     @Override
+    @Cacheable("orders")
     public List<Order> getAll() {
         logger.info("service");
         return orderRepo.findAll();
     }
 
     @Override
+    @CacheEvict(value = "orders", allEntries = true)
     public Order create(CreateOrderRequest createOrderRequest) {
         UserResponse userResponse = getInforUser.getInfor(createOrderRequest.getCustomerId()).getBody();
         Order order = new Order();

--- a/order_service/src/main/java/com/example/microservice_demo/service/serviceImpl/ProductService.java
+++ b/order_service/src/main/java/com/example/microservice_demo/service/serviceImpl/ProductService.java
@@ -5,6 +5,7 @@ import com.example.microservice_demo.repository.ProductRepo;
 import com.example.microservice_demo.service.IProductService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.cache.annotation.Cacheable;
 
 import java.util.List;
 
@@ -14,6 +15,7 @@ public class ProductService implements IProductService {
     @Autowired
     private ProductRepo productRepo;
     @Override
+    @Cacheable("products")
     public List<Product> getAll() {
         return productRepo.findAll();
     }

--- a/order_service/src/main/resources/application.yml
+++ b/order_service/src/main/resources/application.yml
@@ -34,6 +34,11 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+  cache:
+    type: redis
+    cache-names: categories,products,orders
+    redis:
+      time-to-live: 600000
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Summary
- add Redis and cache dependencies
- enable caching and configure Redis cache manager
- annotate services with cacheable/evict and add cache properties

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cef886d483239502d2ccf00d54ab